### PR TITLE
Prevent player death after picking up first chest and reversing

### DIFF
--- a/internal/characters/players/player.go
+++ b/internal/characters/players/player.go
@@ -62,11 +62,12 @@ func (pc *Constructor) Copy() *Constructor {
 
 type Player struct {
 	*entities.Interactive
-	facing      string
-	Swtch       *render.Switch
-	Alive       bool
-	RunSpeed    float64
-	ChestValues []int64
+	facing             string
+	Swtch              *render.Switch
+	Alive              bool
+	ForcedInvulnerable bool
+	RunSpeed           float64
+	ChestValues        []int64
 }
 
 func (p *Player) Init() event.CID {
@@ -122,9 +123,11 @@ func (pc *Constructor) NewPlayer() (*Player, error) {
 
 	p.CheckedBind(func(p *Player, _ interface{}) int {
 		p.RunSpeed *= -1
+		p.ForcedInvulnerable = true
 		p.CheckedBind(func(p *Player, _ interface{}) int {
 			// Shift the player back until against the right wall
 			if int(p.X())-oak.ViewPos.X >= oak.ScreenWidth-WallOffset {
+				p.ForcedInvulnerable = false
 				return event.UnbindSingle
 			}
 			p.ShiftX(-p.RunSpeed * 2)

--- a/internal/run/scene.go
+++ b/internal/run/scene.go
@@ -78,10 +78,15 @@ var Scene = scene.Scene{
 		}
 		render.Draw(s.R, 2, 2)
 		rs := s.GetReactiveSpace()
+
+		// Interaction with Enemies
 		rs.Add(labels.Enemy, func(s, _ *collision.Space) {
 			ply, ok := s.CID.E().(*players.Player)
 			if !ok {
 				dlog.Error("Non-player sent to player binding")
+				return
+			}
+			if ply.ForcedInvulnerable {
 				return
 			}
 			ply.Alive = false
@@ -155,13 +160,14 @@ var Scene = scene.Scene{
 			}
 		})
 
+		// Player got back to the Inn!
 		rs.Add(labels.Door, func(_, _ *collision.Space) {
 			stayInGame = false
-
 			runInfo = records.RunInfo{Party: []*players.Player{s}}
 
 		})
 
+		// Section creation bind to support infinite* hallway
 		event.GlobalBind(func(int, interface{}) int {
 			// This calculation needs to be modified based
 			// on how much of the screen a section takes up.
@@ -195,6 +201,7 @@ var Scene = scene.Scene{
 				s.ShiftX(-w)
 				go func() {
 					nextSct = tracker.Produce(int64(facing))
+					//fmt.Println("Sec", nextSct.GetID(), "total", tracker.SectionsDeep())
 					nextSct.SetBackgroundX(sct.X() + w)
 					nextSct.Draw()
 					if tracker.AtStart() {

--- a/internal/run/section/tracker.go
+++ b/internal/run/section/tracker.go
@@ -55,6 +55,10 @@ func (st *Tracker) AtStart() bool {
 	return st.sectionsDeep == 1
 }
 
+func (st *Tracker) SectionsDeep() int64 {
+	return st.sectionsDeep
+}
+
 func (st *Tracker) At() int64 {
 	return st.sectionsDeep
 }


### PR DESCRIPTION
I think we should prevent the player from dying when they dont have full control. 

This is the proposed change, however I would like to see if others agree on this.